### PR TITLE
Added customHeaders for CORS errors. sp we can login on Amplify

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -13,7 +13,16 @@ frontend:
   artifacts:
     baseDirectory: build
     files:
-      - "**/*"
+      - '**/*'
   cache:
     paths:
       - node_modules/**/*
+  customHeaders:
+    - pattern: '**/manifest.json'
+      headers:
+        - key: 'Access-Control-Allow-Origin'
+          value: '*'
+        - key: 'Access-Control-Allow-Headers'
+          value: '*'
+        - key: 'Access-Control-Allow-Methods'
+          value: 'GET'


### PR DESCRIPTION
CORS issue came up on deployed version of app on Amplify, added customHeaders to amplify.yaml to fix this so we can login